### PR TITLE
Remove Code tab from Icons

### DIFF
--- a/stories/icon.scss
+++ b/stories/icon.scss
@@ -5,10 +5,37 @@
 // ----------
 
 .Icon {
+  &__Copy {
+    button {
+      @include mercury.Manifold__Typography__SubheadingSmall;
+
+      display: flex;
+      align-items: center;
+      padding: 0;
+      color: mercury.$color-grayDark;
+      background: none;
+      border: none;
+      cursor: pointer;
+      transition: color 150ms linear;
+      appearance: none;
+
+      &:hover {
+        color: mercury.$color-blue;
+      }
+    }
+
+    svg {
+      display: block;
+      width: 1em;
+      height: 1em;
+      margin-right: 0.5em;
+    }
+  }
+
   &__SVG {
     padding: 1rem;
 
-    & svg {
+    svg {
       display: block;
       width: 2rem;
       height: 2rem;
@@ -16,6 +43,8 @@
   }
 
   &__Name {
+    display: flex;
+    justify-content: space-between;
     padding: 0 1rem 1rem 1rem;
     font-size: 10px;
     font-family: mercury.$typography-monoBody-fontFamily;

--- a/stories/icon.stories.js
+++ b/stories/icon.stories.js
@@ -1,6 +1,7 @@
 import React from 'react';
+import ReactCopyButtonWrapper from 'react-copy-button-wrapper';
 import icons from './storybook/icons.json';
-import { Story, Code } from './storybook/blocks';
+import { Story } from './storybook/blocks';
 import './icon.scss';
 
 export default { title: 'Icons' };
@@ -12,8 +13,16 @@ export const gallery = () => (
       return (
         <Story small>
           <div className="Icon__SVG" dangerouslySetInnerHTML={{ __html: svg }} />
-          <div className="Icon__Name">{name}</div>
-          <Code tabs={{ html: svg }} />
+          <div className="Icon__Name">
+            {name}
+            <div className="Icon__Copy">
+              <ReactCopyButtonWrapper text={svg}>
+                <button>
+                  <div dangerouslySetInnerHTML={{ __html: icons['copy.svg'] }} /> Copy
+                </button>
+              </ReactCopyButtonWrapper>
+            </div>
+          </div>
         </Story>
       );
     })}


### PR DESCRIPTION
<img width="960" alt="Screen Shot 2020-04-17 at 12 39 39" src="https://user-images.githubusercontent.com/1369770/79602916-9885fb80-80a8-11ea-8b74-f18c44442363.png">

Recently we added a PrismJS autoloader that would automatically syntax highlight any language on your page.

That was really cool, but if you visited the Icon page, it would fry your computer and crash your browser. I guess it can’t handle ~100 code blocks or so. This disables the code blocks in the Icons page because it wasn’t super-helpful anyway.