### PR TITLE
Rename everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ collection and converting it to a file output. Currently we have 2 targets: **JS
 Each of those map to a file in [`./figma/targets`][local-targets]. The JS target is the simplest, as
 it basically writes the object as-is from transformers. The Sass target has to do a little more
 work, converting JS (`{ fontSize: '12px' }`) to CSS strings (`font-size: 12px;`), as well as
-generating some wrappers (`@mixin Manifold__Typography { … }`). But overall, it’s not too much work.
+generating some wrappers (`@mixin Typography { … }`). But overall, it’s not too much work.
 
 _OK, but how do I add something?_ Your process from here will be somewhat trial-and-error, because
 every “thing” you want to add will follow a different process (compare the `color` vs `typography`

--- a/figma/targets/sass.ts
+++ b/figma/targets/sass.ts
@@ -56,7 +56,7 @@ function buildTypography(typography: DesignTokens['typography']): string {
     .map(
       ([key, styles]) =>
         `
-@mixin Manifold__Typography__${capitalize(key)} {${cssifyObject(styles)}}`
+@mixin Typography__${capitalize(key)} {${cssifyObject(styles)}}`
     )
     .join('\n\n');
 

--- a/src/components/_banner.scss
+++ b/src/components/_banner.scss
@@ -1,7 +1,7 @@
 @use "../design-tokens/color";
 @use "../design-tokens/typography";
 
-@mixin Manifold__Banner {
+@mixin Banner {
   position: relative;
   display: flex;
   box-sizing: border-box;
@@ -39,14 +39,14 @@
     flex-shrink: 1;
     margin-top: 1px;
     margin-bottom: 0;
-    @include typography.Manifold__Typography__SmallScreenBody;
+    @include typography.Typography__SmallScreenBody;
     @media (min-width: 600px) {
-      @include typography.Manifold__Typography__Body;
+      @include typography.Typography__Body;
     }
   }
 }
 
-@mixin Manifold__Banner--Error {
+@mixin Banner--Error {
   &::before {
     background-color: color.$color-red;
     border: 1px solid color.$color-red;
@@ -57,7 +57,7 @@
   }
 }
 
-@mixin Manifold__Banner--Warning {
+@mixin Banner--Warning {
   &::before {
     background-color: color.$color-orange;
     border: 1px solid color.$color-orange;
@@ -68,7 +68,7 @@
   }
 }
 
-@mixin Manifold__Banner--Success {
+@mixin Banner--Success {
   &::before {
     background-color: color.$color-green;
     border: 1px solid color.$color-green;

--- a/src/components/_button.scss
+++ b/src/components/_button.scss
@@ -10,7 +10,7 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
 //  Button
 // ----------
 
-@mixin Manifold__Button {
+@mixin Button {
   position: relative;
   display: inline-block;
   box-sizing: border-box;
@@ -73,7 +73,7 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
   }
 
   &:disabled {
-    @include Manifold__Button--Disabled;
+    @include Button--Disabled;
   }
 }
 
@@ -81,7 +81,7 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
 //  Modifiers
 // ----------
 
-@mixin Manifold__Button--Black {
+@mixin Button--Black {
   color: color.$color-white;
   background: color.$color-grayDarker;
   border-color: color.$color-grayDarker;
@@ -92,11 +92,11 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
   }
 
   &:disabled {
-    @include Manifold__Button--Disabled;
+    @include Button--Disabled;
   }
 }
 
-@mixin Manifold__Button--Brand {
+@mixin Button--Brand {
   color: color.$color-white;
   background: gradient.$gradient-brand;
   border-color: transparent;
@@ -107,11 +107,11 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
   }
 
   &:disabled {
-    @include Manifold__Button--Disabled;
+    @include Button--Disabled;
   }
 }
 
-@mixin Manifold__Button--Danger {
+@mixin Button--Danger {
   color: color.$color-red;
   background: color.$color-white;
   border-color: currentColor;
@@ -122,11 +122,11 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
   }
 
   &:disabled {
-    @include Manifold__Button--Disabled;
+    @include Button--Disabled;
   }
 }
 
-@mixin Manifold__Button--Disabled {
+@mixin Button--Disabled {
   color: color.$color-gray;
   background: color.$color-grayLighter;
   border: 1px solid color.$color-utilitiesGray;
@@ -155,7 +155,7 @@ $button-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
   }
 }
 
-@mixin Manifold__Button--Small {
+@mixin Button--Small {
   padding: 8px 14px;
   font-size: 13px;
 }

--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -5,7 +5,7 @@
 //  Input
 // ----------
 
-@mixin Manifold__Input {
+@mixin Input {
   transition: border-color 150ms linear;
 
   // ----------
@@ -13,7 +13,7 @@
   // ----------
 
   label {
-    @include typography.Manifold__Typography__SubheadingSmall;
+    @include typography.Typography__SubheadingSmall;
 
     display: block;
     padding-bottom: 0.25rem;
@@ -24,7 +24,7 @@
   }
 
   input {
-    @include typography.Manifold__Typography__SmallScreenBody;
+    @include typography.Typography__SmallScreenBody;
 
     display: block;
     box-sizing: border-box;
@@ -44,7 +44,7 @@
     appearance: none;
 
     @media (min-width: 600px) {
-      @include typography.Manifold__Typography__Body;
+      @include typography.Typography__Body;
     }
 
     &:hover {
@@ -56,7 +56,7 @@
     &[inputmode='decimal'],
     &[pattern='[0-9]*'],
     &[pattern^='\d'] {
-      @include typography.Manifold__Typography__MonoBody;
+      @include typography.Typography__MonoBody;
 
       text-align: right;
     }
@@ -99,7 +99,7 @@
 
 $input-label-width: 4rem;
 
-@mixin Manifold__Input--Inline {
+@mixin Input--Inline {
   position: relative;
 
   label {

--- a/src/components/_modal.scss
+++ b/src/components/_modal.scss
@@ -13,7 +13,7 @@ $modal-corner-radius: 4px;
 //  Modal
 // ----------
 
-@mixin Manifold__Modal {
+@mixin Modal {
   position: fixed;
   top: 0;
   right: 0;
@@ -69,7 +69,7 @@ $modal-corner-radius: 4px;
 //  Elements
 //  ----------
 
-@mixin Manifold__Modal__Close {
+@mixin Modal__Close {
   position: absolute;
   top: 0;
   right: 0;
@@ -123,7 +123,7 @@ $modal-corner-radius: 4px;
   }
 }
 
-@mixin Manifold__Modal__Footer {
+@mixin Modal__Footer {
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -143,7 +143,7 @@ $modal-corner-radius: 4px;
 //  Modifiers
 // ----------
 
-@mixin Manifold__Modal--Small {
+@mixin Modal--Small {
   & > div {
     max-width: 50rem;
   }

--- a/src/components/_select.scss
+++ b/src/components/_select.scss
@@ -5,7 +5,7 @@
 //  Select
 // ----------
 
-@mixin Manifold__Select {
+@mixin Select {
   transition: border-color 150ms linear;
 
   // ----------
@@ -13,7 +13,7 @@
   // ----------
 
   label {
-    @include typography.Manifold__Typography__SubheadingSmall;
+    @include typography.Typography__SubheadingSmall;
 
     display: block;
     padding-bottom: 0.25rem;
@@ -24,7 +24,7 @@
   }
 
   select {
-    @include typography.Manifold__Typography__SmallScreenBody;
+    @include typography.Typography__SmallScreenBody;
 
     display: block;
     box-sizing: border-box;
@@ -60,7 +60,7 @@
     }
 
     @media (min-width: 600px) {
-      @include typography.Manifold__Typography__Body;
+      @include typography.Typography__Body;
     }
   }
 
@@ -107,7 +107,7 @@
 
 $select-label-width: 4rem;
 
-@mixin Manifold__Select--Inline {
+@mixin Select--Inline {
   position: relative;
 
   label {

--- a/src/components/_skeleton.scss
+++ b/src/components/_skeleton.scss
@@ -1,5 +1,5 @@
-@mixin Manifold__Skeleton {
-  @keyframes Manifold__Skeleton__Animation {
+@mixin Skeleton {
+  @keyframes Skeleton__Animation {
     to {
       transform: translateX(125%);
     }
@@ -45,7 +45,7 @@
     );
     background-repeat: no-repeat;
     opacity: 0.4;
-    animation-name: Manifold__Skeleton__Animation;
+    animation-name: Skeleton__Animation;
     animation-duration: 1.4s;
     animation-timing-function: linear;
     animation-iteration-count: infinite;
@@ -54,7 +54,7 @@
   }
 }
 
-@mixin Manifold__Skeleton--White {
+@mixin Skeleton--White {
   &::before {
     background-image: linear-gradient(
       rgba(255, 255, 255, 0.25),

--- a/src/components/_toast.scss
+++ b/src/components/_toast.scss
@@ -2,7 +2,7 @@
 @use "../design-tokens/typography";
 @use "../design-tokens/shadow";
 
-@mixin Manifold__Toast {
+@mixin Toast {
   display: flex;
   flex-direction: row;
   padding: 9px 16px 7px;
@@ -10,7 +10,7 @@
   background-color: color.$color-grayDarker;
   border-radius: 4px;
   box-shadow: shadow.$shadow-far;
-  @include typography.Manifold__Typography__Label;
+  @include typography.Typography__Label;
 
   > svg {
     flex-grow: 0;
@@ -33,6 +33,6 @@
   }
 }
 
-@mixin Manifold__Toast--Error {
+@mixin Toast--Error {
   background-color: color.$color-red;
 }

--- a/src/components/_toggle.scss
+++ b/src/components/_toggle.scss
@@ -8,7 +8,7 @@ $toggle-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
 
 /* stylelint-disable selector-max-specificity */
 
-@mixin Manifold__Toggle {
+@mixin Toggle {
   position: relative;
   display: flex;
   align-items: center;
@@ -33,7 +33,7 @@ $toggle-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
   // ----------
 
   label {
-    @include typography.Manifold__Typography__SmallScreenBody;
+    @include typography.Typography__SmallScreenBody;
 
     position: relative;
     display: flex;
@@ -44,7 +44,7 @@ $toggle-ease-out-sine: cubic-bezier(0, 0.5, 0.5, 1);
     cursor: pointer;
 
     @media (min-width: 600px) {
-      @include typography.Manifold__Typography__Body;
+      @include typography.Typography__Body;
     }
 
     &::before {

--- a/src/components/_tooltip.scss
+++ b/src/components/_tooltip.scss
@@ -8,7 +8,7 @@ $tooltip-arrow-size: 5px;
 $tooltip-color: color.$color-grayDarker;
 $tooltip-margin: 8px;
 
-@mixin Manifold__Tooltip__Container {
+@mixin Tooltip__Container {
   position: relative;
   cursor: pointer;
 
@@ -31,7 +31,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip__Container--Down {
+@mixin Tooltip__Container--Down {
   [role='tooltip'] {
     top: 100%;
     bottom: auto;
@@ -45,7 +45,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip__Container--Left {
+@mixin Tooltip__Container--Left {
   [role='tooltip'] {
     top: 50%;
     right: 100%;
@@ -61,7 +61,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip__Container--Right {
+@mixin Tooltip__Container--Right {
   [role='tooltip'] {
     top: 50%;
     bottom: auto;
@@ -76,7 +76,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip {
+@mixin Tooltip {
   position: relative;
   padding: 8px 12px;
   color: color.$color-white;
@@ -88,7 +88,7 @@ $tooltip-margin: 8px;
   box-shadow: shadow.$shadow-near;
   cursor: default;
   pointer-events: none;
-  @include typography.Manifold__Typography__Caption;
+  @include typography.Typography__Caption;
 
   &::after {
     position: absolute;
@@ -106,7 +106,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip--Down {
+@mixin Tooltip--Down {
   &::after {
     top: auto;
     bottom: 100%;
@@ -115,7 +115,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip--Left {
+@mixin Tooltip--Left {
   &::after {
     top: 50%;
     left: 100%;
@@ -126,7 +126,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip--Right {
+@mixin Tooltip--Right {
   &::after {
     top: 50%;
     right: 100%;
@@ -138,7 +138,7 @@ $tooltip-margin: 8px;
   }
 }
 
-@mixin Manifold__Tooltip--Large {
+@mixin Tooltip--Large {
   width: 260px;
   line-height: 1.25;
   white-space: normal;

--- a/src/design-tokens/_typography.scss
+++ b/src/design-tokens/_typography.scss
@@ -152,7 +152,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
   'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
   'Segoe UI Emoji';
 
-@mixin Manifold__Typography__Body {
+@mixin Typography__Body {
   font-size: 16px;
   font-weight: 400;
   letter-spacing: normal;
@@ -162,7 +162,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__Caption {
+@mixin Typography__Caption {
   font-size: 12px;
   font-weight: 400;
   letter-spacing: normal;
@@ -172,7 +172,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__Heading {
+@mixin Typography__Heading {
   font-size: 20px;
   font-weight: 400;
   letter-spacing: normal;
@@ -182,7 +182,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__HeadingExtraLarge {
+@mixin Typography__HeadingExtraLarge {
   font-size: 32px;
   font-weight: 500;
   letter-spacing: normal;
@@ -192,7 +192,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__HeadingLarge {
+@mixin Typography__HeadingLarge {
   font-size: 25px;
   font-weight: 400;
   letter-spacing: normal;
@@ -202,7 +202,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__Label {
+@mixin Typography__Label {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: normal;
@@ -212,7 +212,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__MonoBody {
+@mixin Typography__MonoBody {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: normal;
@@ -222,7 +222,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     Menlo, monospace;
 }
 
-@mixin Manifold__Typography__MonoCaption {
+@mixin Typography__MonoCaption {
   font-size: 10px;
   font-weight: 400;
   letter-spacing: normal;
@@ -232,7 +232,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     Menlo, monospace;
 }
 
-@mixin Manifold__Typography__MonoLabel {
+@mixin Typography__MonoLabel {
   font-size: 12px;
   font-weight: 400;
   letter-spacing: normal;
@@ -242,7 +242,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     Menlo, monospace;
 }
 
-@mixin Manifold__Typography__SidebarBigTitle {
+@mixin Typography__SidebarBigTitle {
   font-size: 16px;
   font-weight: 600;
   letter-spacing: normal;
@@ -252,7 +252,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SidebarSmallTitle {
+@mixin Typography__SidebarSmallTitle {
   font-size: 14px;
   font-weight: 700;
   letter-spacing: normal;
@@ -262,7 +262,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenBody {
+@mixin Typography__SmallScreenBody {
   font-size: 16px;
   font-weight: 400;
   letter-spacing: normal;
@@ -272,7 +272,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenCaption {
+@mixin Typography__SmallScreenCaption {
   font-size: 13px;
   font-weight: 400;
   letter-spacing: normal;
@@ -282,7 +282,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenHeading {
+@mixin Typography__SmallScreenHeading {
   font-size: 18px;
   font-weight: 400;
   letter-spacing: normal;
@@ -292,7 +292,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenHeadingExtraLarge {
+@mixin Typography__SmallScreenHeadingExtraLarge {
   font-size: 26px;
   font-weight: 500;
   letter-spacing: normal;
@@ -302,7 +302,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenHeadingLarge {
+@mixin Typography__SmallScreenHeadingLarge {
   font-size: 22px;
   font-weight: 400;
   letter-spacing: normal;
@@ -312,7 +312,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenLabel {
+@mixin Typography__SmallScreenLabel {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: normal;
@@ -322,7 +322,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SmallScreenSubheading {
+@mixin Typography__SmallScreenSubheading {
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -332,7 +332,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__Subheading {
+@mixin Typography__Subheading {
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -342,7 +342,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Manifold__Typography__SubheadingSmall {
+@mixin Typography__SubheadingSmall {
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.04em;

--- a/stories/banner.scss
+++ b/stories/banner.scss
@@ -4,22 +4,22 @@
 // Block
 // ----------
 
-.Manifold__Banner {
-  @include mercury.Manifold__Banner;
+.Manifold-Banner {
+  @include mercury.Banner;
 
   // ----------
   //  Modifiers
   // ----------
 
   &--Error {
-    @include mercury.Manifold__Banner--Error;
+    @include mercury.Banner--Error;
   }
 
   &--Warning {
-    @include mercury.Manifold__Banner--Warning;
+    @include mercury.Banner--Warning;
   }
 
   &--Success {
-    @include mercury.Manifold__Banner--Success;
+    @include mercury.Banner--Success;
   }
 }

--- a/stories/banner.stories.js
+++ b/stories/banner.stories.js
@@ -9,7 +9,7 @@ export default { title };
 export const defaultBanner = () => (
   <Story>
     <Demo>
-      <div role="alert" className="Manifold__Banner">
+      <div role="alert" className="Manifold-Banner">
         <svg aria-label="info" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <g fill-rule="evenodd" clip-rule="evenodd">
             <path d="M12 3a9 9 0 100 18 9 9 0 000-18zM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12z" />
@@ -28,14 +28,14 @@ export const defaultBanner = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div role="alert" class="Manifold__Banner">
+        html: `<div role="alert" class="Manifold-Banner">
   <svg aria-label="info" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd" clip-rule="evenodd"><path d="M12 3a9 9 0 100 18 9 9 0 000-18zM1 12C1 5.925 5.925 1 12 1s11 4.925 11 11-4.925 11-11 11S1 18.075 1 12z" /><path d="M12 11a1 1 0 011 1v4a1 1 0 11-2 0v-4a1 1 0 011-1zM11 8a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1z" /></g></svg>
   <p>Generic information uses a basic message bar.</p>
 </div>`,
         scss: `${comment.block(title)}
 
-.Manifold__Banner {
-  @include mercury.Manifold__Banner;
+.Manifold-Banner {
+  @include mercury.Banner;
 }`,
       }}
     />
@@ -45,7 +45,7 @@ export const defaultBanner = () => (
 export const error = () => (
   <Story>
     <Demo>
-      <div role="alert" className="Manifold__Banner Manifold__Banner--Error">
+      <div role="alert" className="Manifold-Banner Manifold-Banner--Error">
         <svg
           aria-label="alert-triangle"
           role="img"
@@ -66,19 +66,19 @@ export const error = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div role="alert" class="Manifold__Banner Manifold__Banner--Error">
+        html: `<div role="alert" class="Manifold-Banner Manifold-Banner--Error">
   <svg aria-label="alert-triangle" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><g fill-rule="evenodd" clip-rule="evenodd"><path d="M10.528 2.283a3 3 0 014.037 1.058l.003.005 8.47 14.14.008.014a3 3 0 01-2.565 4.5H3.519a2.999 2.999 0 01-2.565-4.5l.008-.014 8.47-14.14.858.514-.855-.519a3 3 0 011.093-1.058zm.618 2.094L2.683 18.506A1 1 0 003.536 20h16.928a1 1 0 00.853-1.494L12.855 4.379l-.001-.002a1 1 0 00-1.708 0z" /><path d="M11 17a1 1 0 011-1h.01a1 1 0 110 2H12a1 1 0 01-1-1zM12 8a1 1 0 011 1v4a1 1 0 11-2 0V9a1 1 0 011-1z" /></g></svg>
   <p>Uh oh, something is wrong. Please review the wrong thing.</p>
 </div>`,
         scss: `${comment.block(title)}
 
-.Manifold__Banner {
-  @include mercury.Manifold__Banner;
+.Manifold-Banner {
+  @include mercury.Banner;
 
   ${comment.modifier}
 
   &--Error {
-    @include mercury.Manifold__Banner--Error;
+    @include mercury.Banner--Error;
   }
 }`,
       }}
@@ -89,7 +89,7 @@ export const error = () => (
 export const success = () => (
   <Story>
     <Demo>
-      <div role="alert" className="Manifold__Banner Manifold__Banner--Success">
+      <div role="alert" className="Manifold-Banner Manifold-Banner--Success">
         <svg aria-label="check" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path
             fill-rule="evenodd"
@@ -106,19 +106,19 @@ export const success = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div role="alert" class="Manifold__Banner Manifold__Banner--Success">
+        html: `<div role="alert" class="Manifold-Banner Manifold-Banner--Success">
   <svg aria-label="check" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M20.707 5.293a1 1 0 010 1.414l-11 11a1 1 0 01-1.414 0l-5-5a1 1 0 111.414-1.414L9 15.586 19.293 5.293a1 1 0 011.414 0z" /></svg>
   <p>Look at that! An absolute success, nice work.</p>
 </div>`,
         scss: `${comment.block(title)}
 
-.Manifold__Banner {
-  @include mercury.Manifold__Banner;
+.Manifold-Banner {
+  @include mercury.Banner;
 
   ${comment.modifier}
 
   &--Success {
-    @include mercury.Manifold__Banner--Success;
+    @include mercury.Banner--Success;
   }
 }`,
       }}
@@ -129,7 +129,7 @@ export const success = () => (
 export const warning = () => (
   <Story>
     <Demo>
-      <div role="alert" className="Manifold__Banner Manifold__Banner--Warning">
+      <div role="alert" className="Manifold-Banner Manifold-Banner--Warning">
         <svg aria-label="flag" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path
             fill-rule="evenodd"
@@ -147,19 +147,19 @@ export const warning = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div role="alert" class="Manifold__Banner Manifold__Banner--Warning">
+        html: `<div role="alert" class="Manifold-Banner Manifold-Banner--Warning">
   <svg aria-label="flag" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path fill-rule="evenodd" clip-rule="evenodd" d="M4 14a1 1 0 011 1v7a1 1 0 11-2 0v-7a1 1 0 011-1z" /><path d="M16 17c-1.7 0-3.1-.5-4.4-1.1-1.2-.4-2.3-.9-3.6-.9-2.4 0-3.3.7-3.3.7-.3.3-.7.4-1.1.2-.4-.2-.6-.5-.6-.9V3c0-.3.1-.5.3-.7C3.5 2.1 4.8 1 8 1c1.7 0 3.1.5 4.4 1.1 1.2.4 2.3.9 3.6.9 2.4 0 3.3-.7 3.3-.7.3-.3.7-.4 1.1-.2.4.2.6.5.6.9v12c0 .3-.1.5-.3.7-.2.2-1.4 1.3-4.7 1.3zm-8-4c1.7 0 3.1.5 4.4 1.1 1.2.5 2.3.9 3.6.9 1.6 0 2.6-.3 3-.5V4.6c-.7.2-1.7.4-3 .4-1.7 0-3.1-.5-4.4-1.1C10.4 3.5 9.3 3 8 3c-1.6 0-2.6.3-3 .5v9.9c.7-.2 1.7-.4 3-.4z" /></svg>
   <p>This is your final warning.</p>
 </div>`,
         scss: `${comment.block(title)}
 
-.Manifold__Banner {
-  @include mercury.Manifold__Banner;
+.Manifold-Banner {
+  @include mercury.Banner;
 
   ${comment.modifier}
 
   &--Warning {
-    @include mercury.Manifold__Banner--Warning;
+    @include mercury.Banner--Warning;
   }
 }`,
       }}

--- a/stories/button.scss
+++ b/stories/button.scss
@@ -4,26 +4,26 @@
 // Block
 // ----------
 
-.Manifold__Button {
-  @include mercury.Manifold__Button;
+.Manifold-Button {
+  @include mercury.Button;
 
   // ----------
   //  Modifiers
   // ----------
 
   &--Black {
-    @include mercury.Manifold__Button--Black;
+    @include mercury.Button--Black;
   }
 
   &--Brand {
-    @include mercury.Manifold__Button--Brand;
+    @include mercury.Button--Brand;
   }
 
   &--Danger {
-    @include mercury.Manifold__Button--Danger;
+    @include mercury.Button--Danger;
   }
 
   &--Small {
-    @include mercury.Manifold__Button--Small;
+    @include mercury.Button--Small;
   }
 }

--- a/stories/button.stories.js
+++ b/stories/button.stories.js
@@ -9,8 +9,8 @@ export default { title };
 export const defaultButton = () => (
   <Story>
     <Demo>
-      <button className="Manifold__Button">Default Button</button>
-      <button className="Manifold__Button Manifold__Button--Black">Default Button (Black)</button>
+      <button className="Manifold-Button">Default Button</button>
+      <button className="Manifold-Button Manifold-Button--Black">Default Button (Black)</button>
     </Demo>
     <Description>
       <h1>Default</h1>
@@ -19,28 +19,28 @@ export const defaultButton = () => (
     <Code
       tabs={{
         html: `<!-- button -->
-<button class="Manifold__Button" type="button">
+<button class="Manifold-Button" type="button">
   Default Button
 </button>
 
 <!-- black button -->
-<button class="Manifold__Button Manifold__Button--Black" type="button">
+<button class="Manifold-Button Manifold-Button--Black" type="button">
   Default Button (Black)
 </button>
 
 <!-- link -->
-<a href="#" class="Manifold__Button">
+<a href="#" class="Manifold-Button">
   Default Link
 </a>`,
         scss: `${comment.block(title)}
 
-.Manifold__Button {
-  @include mercury.Manifold__Button;
+.Manifold-Button {
+  @include mercury.Button;
 
   ${comment.modifier}
 
   &--Black {
-    @include mercury.Manifold__Button--Black
+    @include mercury.Button--Black
   }
 }`,
       }}
@@ -51,7 +51,7 @@ export const defaultButton = () => (
 export const brand = () => (
   <Story>
     <Demo>
-      <button className="Manifold__Button Manifold__Button--Brand">Brand Button</button>
+      <button className="Manifold-Button Manifold-Button--Brand">Brand Button</button>
     </Demo>
     <Description>
       <h1>Brand</h1>
@@ -63,23 +63,23 @@ export const brand = () => (
     <Code
       tabs={{
         html: `<!-- button -->
-<button class="Manifold__Button Manifold__Button--Brand" type="button">
+<button class="Manifold-Button Manifold-Button--Brand" type="button">
   Brand Button
 </button>
 
 <!-- link -->
-<a href="#" class="Manifold__Button Manifold__Button--Brand">
+<a href="#" class="Manifold-Button Manifold-Button--Brand">
   Brand Link
 </a>`,
         scss: `${comment.block(title)}
 
-.Manifold__Button {
-  @include mercury.Manifold__Button;
+.Manifold-Button {
+  @include mercury.Button;
 
   ${comment.modifier}
 
   &--Brand {
-    @include mercury.Manifold__Button--Brand;
+    @include mercury.Button--Brand;
   }
 }`,
       }}
@@ -90,7 +90,7 @@ export const brand = () => (
 export const danger = () => (
   <Story>
     <Demo>
-      <button className="Manifold__Button Manifold__Button--Danger">Danger Button</button>
+      <button className="Manifold-Button Manifold-Button--Danger">Danger Button</button>
     </Demo>
     <Description>
       <h1>Danger</h1>
@@ -100,18 +100,18 @@ export const danger = () => (
     </Description>
     <Code
       tabs={{
-        html: `<button class="Manifold__Button Manifold__Button--Danger" type="button">
+        html: `<button class="Manifold-Button Manifold-Button--Danger" type="button">
   Danger Button
 </button>`,
         scss: `${comment.block(title)}
 
-.Manifold__Button {
-  @include mercury.Manifold__Button;
+.Manifold-Button {
+  @include mercury.Button;
 
   ${comment.modifier}
 
   &--Danger {
-    @include mercury.Manifold__Button--Danger;
+    @include mercury.Button--Danger;
   }
 }`,
       }}
@@ -122,7 +122,7 @@ export const danger = () => (
 export const small = () => (
   <Story>
     <Demo>
-      <button className="Manifold__Button Manifold__Button--Small">Default Small</button>
+      <button className="Manifold-Button Manifold-Button--Small">Default Small</button>
     </Demo>
     <Description>
       <h1>Small</h1>
@@ -134,23 +134,23 @@ export const small = () => (
     <Code
       tabs={{
         html: `<!-- button -->
-<button class="Manifold__Button Manifold__Button--Small" type="button">
+<button class="Manifold-Button Manifold-Button--Small" type="button">
   Small Button
 </button>
 
 <!-- link -->
-<a href="#" class="Manifold__Button Manifold__Button--Small">
+<a href="#" class="Manifold-Button Manifold-Button--Small">
   Small Link
 </a>`,
         scss: `${comment.block(title)}
 
-.Manifold__Button {
-  @include mercury.Manifold__Button;
+.Manifold-Button {
+  @include mercury.Button;
 
   ${comment.modifier}
 
   &--Small {
-    @include mercury.Manifold__Button--Small;
+    @include mercury.Button--Small;
   }
 }`,
       }}
@@ -161,7 +161,7 @@ export const small = () => (
 export const disabled = () => (
   <Story>
     <Demo>
-      <button disabled className="Manifold__Button">
+      <button disabled className="Manifold-Button">
         Disabled Button
       </button>
     </Demo>
@@ -174,13 +174,13 @@ export const disabled = () => (
     </Description>
     <Code
       tabs={{
-        html: `<button disabled class="Manifold__Button" type="button">
+        html: `<button disabled class="Manifold-Button" type="button">
   Disabled Button
 </button>`,
         scss: `${comment.block(title)}
 
-.Manifold__Button {
-  @include mercury.Manifold__Button;
+.Manifold-Button {
+  @include mercury.Button;
 }`,
       }}
     />

--- a/stories/icon.scss
+++ b/stories/icon.scss
@@ -7,7 +7,7 @@
 .Icon {
   &__Copy {
     button {
-      @include mercury.Manifold__Typography__SubheadingSmall;
+      @include mercury.Typography__SubheadingSmall;
 
       display: flex;
       align-items: center;

--- a/stories/input.scss
+++ b/stories/input.scss
@@ -4,14 +4,14 @@
 //  Input
 // ----------
 
-.Manifold__Input {
-  @include mercury.Manifold__Input;
+.Manifold-Input {
+  @include mercury.Input;
 
   // ----------
   //  Modifiers
   // ----------
 
   &--Inline {
-    @include mercury.Manifold__Input--Inline;
+    @include mercury.Input--Inline;
   }
 }

--- a/stories/input.stories.js
+++ b/stories/input.stories.js
@@ -8,25 +8,25 @@ export const input = () => (
   <Story>
     <Demo>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="text">Text input</label>
           <input type="text" autoCapitalize="off" name="text" id="text" placeholder="Placeholder" />
         </div>
       </div>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="email">Email</label>
           <input type="email" name="email" id="email" value="info@manifold.co" />
         </div>
       </div>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="password">Password</label>
           <input type="password" name="password" id="password" />
         </div>
       </div>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="number">Numeric</label>
           <input type="text" inputmode="decimal" pattern="\d+(\.\d*)?" name="number" id="number" />
         </div>
@@ -50,32 +50,32 @@ export const input = () => (
     <Code
       tabs={{
         html: `<!-- text input -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="text">Text input</label>
   <input type="text" autocapitalize="off" name="text" id="text" />
 </div>
 
 <!-- email input -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="email">Email</label>
   <input type="email" name="email" id="email" />
 </div>
 
 <!-- password input -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="password">Password</label>
   <input type="password" name="password" id="password" />
 </div>
 
 <!-- numeric input -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="number">Numeric input</label>
   <input type="text" inputmode="decimal" pattern="\d+(\.\d*)?" name="number" id="number" />
 </div>`,
         scss: `${comment.block('Input')}
 
-.Manifold__Input {
-  @include mercury.Manifold__Input;
+.Manifold-Input {
+  @include mercury.Input;
 }`,
       }}
     />
@@ -86,13 +86,13 @@ export const inputState = () => (
   <Story>
     <Demo>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="normal">Normal</label>
           <input type="text" autoCapitalize="off" name="normal" id="normal" value="Input text" />
         </div>
       </div>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="disabled">Disabled</label>
           <input
             disabled
@@ -105,7 +105,7 @@ export const inputState = () => (
         </div>
       </div>
       <div>
-        <div className="Manifold__Input">
+        <div className="Manifold-Input">
           <label for="invalid">Invalid</label>
           <input
             aria-invalid
@@ -154,26 +154,26 @@ export const inputState = () => (
     <Code
       tabs={{
         html: `<!-- normal -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="normal">Normal</label>
   <input type="text" autocapitalize="off" name="normal" id="normal" />
 </div>
 
 <!-- disabled -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="disabled">Disabled</label>
   <input disabled type="text" autocapitalize="off" name="disabled" id="disabled" />
 </div>
 
 <!-- invalid -->
-<div class="Manifold__Input">
+<div class="Manifold-Input">
   <label for="invalid">Invalid</label>
   <input aria-invalid type="text" autocapitalize="off" name="invalid" id="invalid" />
 </div>`,
         scss: `${comment.block('Input')}
 
-.Manifold__Input {
-  @include mercury.Manifold__Input;
+.Manifold-Input {
+  @include mercury.Input;
 }`,
       }}
     />
@@ -183,7 +183,7 @@ export const inputState = () => (
 export const inputInline = () => (
   <Story>
     <Demo>
-      <div className="Manifold__Input Manifold__Input--Inline">
+      <div className="Manifold-Input Manifold-Input--Inline">
         <label for="inline-input">Label</label>
         <input
           type="text"
@@ -206,19 +206,19 @@ export const inputInline = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div className="Manifold__Input Manifold__Input--Inline">
+        html: `<div className="Manifold-Input Manifold-Input--Inline">
   <label for="inline-input">Label</label>
   <input type="text" autoCapitalize="off" name="inline-input" id="inline-input" value="Input text" />
 </div>`,
         scss: `${comment.block('Input')}
 
-.Manifold__Input {
-  @include mercury.Manifold__Input;
+.Manifold-Input {
+  @include mercury.Input;
 
   ${comment.modifier}
 
   &--Inline {
-    @include mercury.Manifold__Input--Inline;
+    @include mercury.Input--Inline;
   }
 }`,
       }}

--- a/stories/modal.scss
+++ b/stories/modal.scss
@@ -4,18 +4,18 @@
 //  Modal
 // ----------
 
-.Manifold__Modal {
-  @include mercury.Manifold__Modal;
+.Manifold-Modal {
+  @include mercury.Modal;
 
   // ----------
   //  Elements
   // ----------
 
   &__Close {
-    @include mercury.Manifold__Modal__Close;
+    @include mercury.Modal__Close;
   }
 
   &__Footer {
-    @include mercury.Manifold__Modal__Footer;
+    @include mercury.Modal__Footer;
   }
 }

--- a/stories/modal.stories.js
+++ b/stories/modal.stories.js
@@ -27,12 +27,12 @@ export const modal = () => {
   return (
     <Story>
       <Demo>
-        <button type="button" className="Manifold__Button" onClick={() => openModal()}>
+        <button type="button" className="Manifold-Button" onClick={() => openModal()}>
           Save Game
         </button>
         <div>
           <div
-            className="Manifold__Modal"
+            className="Manifold-Modal"
             role="dialog"
             aria-modal={isModalVisible || undefined}
             aria-labelledby="dialog-title"
@@ -42,7 +42,7 @@ export const modal = () => {
             <div onClick={(e) => e.stopPropagation()}>
               <button
                 type="button"
-                className="Manifold__Modal__Close"
+                className="Manifold-Modal__Close"
                 onClick={() => closeModal()}
                 aria-label="Close"
               >
@@ -54,13 +54,13 @@ export const modal = () => {
               <p id="dialog-desc">
                 Are you sure you want to save your game? This will overwrite previous save data.
               </p>
-              <menu className="Manifold__Modal__Footer">
-                <button type="button" className="Manifold__Button" onClick={() => closeModal()}>
+              <menu className="Manifold-Modal__Footer">
+                <button type="button" className="Manifold-Button" onClick={() => closeModal()}>
                   Cancel
                 </button>
                 <button
                   type="button"
-                  className="Manifold__Button Manifold__Button--Black"
+                  className="Manifold-Button Manifold-Button--Black"
                   onClick={() => closeModal()}
                 >
                   Save
@@ -113,12 +113,12 @@ export const modal = () => {
       <Code
         tabs={{
           html: `<!-- modal hidden (default) -->
-<div class="Manifold__Modal" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-desc">
+<div class="Manifold-Modal" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-desc">
   <div>
-    <button type="button" class="Manifold__Modal__Close" aria-label="Close">✕</button>
+    <button type="button" class="Manifold-Modal__Close" aria-label="Close">✕</button>
     <h1 id="dialog-title">Save</h1>
     <p id="dialog-desc">Are you sure you want to save your game? This will overwrite previous save data.</p>
-    <menu class="Manifold__Modal__Footer">
+    <menu class="Manifold-Modal__Footer">
       <button type="button">Cancel</button>
       <button type="submit">Save</button>
     </menu>
@@ -126,12 +126,12 @@ export const modal = () => {
 </div>
 
 <!-- modal visible -->
-<div aria-modal="true" class="Manifold__Modal" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-desc">
+<div aria-modal="true" class="Manifold-Modal" role="dialog" aria-labelledby="dialog-title" aria-describedby="dialog-desc">
   <div>
-    <button type="button" class="Manifold__Modal__Close" aria-label="Close">✕</button>
+    <button type="button" class="Manifold-Modal__Close" aria-label="Close">✕</button>
     <h1 id="dialog-title">Save</h1>
     <p id="dialog-desc">Are you sure you want to save your game? This will overwrite previous save data.</p>
-    <menu class="Manifold__Modal__Footer">
+    <menu class="Manifold-Modal__Footer">
       <button type="button">Cancel</button>
       <button type="submit">Save</button>
     </menu>
@@ -164,12 +164,12 @@ export const modal = () => {
       <button onClick={() => openModal()} type="button">Save Game</button>
 
       {/* modal */}
-      <div onClick={() => closeModal()} role="dialog" className="Manifold__Modal" aria-modal={isModalVisible || undefined} aria-labelledby="dialog-title" aria-describedby="dialog-desc">
+      <div onClick={() => closeModal()} role="dialog" className="Manifold-Modal" aria-modal={isModalVisible || undefined} aria-labelledby="dialog-title" aria-describedby="dialog-desc">
         <div onClick={(e) => e.stopPropagation()}>
-          <button onClick={() => closeModal()} className="Manifold__Modal__Close" type="button" aria-label="Close">✕</button>
+          <button onClick={() => closeModal()} className="Manifold-Modal__Close" type="button" aria-label="Close">✕</button>
           <h1 id="dialog-title">Save</h1>
           <p id="dialog-desc">Are you sure you want to save your game? This will overwrite previous save data.</p>
-          <menu className="Manifold__Modal__Footer">
+          <menu className="Manifold-Modal__Footer">
             <button type="button">Cancel</button>
             <button type="submit">Save</button>
           </menu>
@@ -180,17 +180,17 @@ export const modal = () => {
 };`,
           scss: `${comment.block('Modal')}
 
-.Manifold__Modal {
-  @include mercury.Manifold__Modal;
+.Manifold-Modal {
+  @include mercury.Modal;
 
   ${comment.element}
 
   &__Close {
-    @include mercury.Manifold__Modal__Close;
+    @include mercury.Modal__Close;
   }
 
   &__Footer {
-    @include mercury.Manifold__Modal__Footer;
+    @include mercury.Modal__Footer;
   }
 }`,
         }}

--- a/stories/select.scss
+++ b/stories/select.scss
@@ -4,14 +4,14 @@
 //  Select
 // ----------
 
-.Manifold__Select {
-  @include mercury.Manifold__Select;
+.Manifold-Select {
+  @include mercury.Select;
 
   // ----------
   //  Modifiers
   // ----------
 
   &--Inline {
-    @include mercury.Manifold__Select--Inline;
+    @include mercury.Select--Inline;
   }
 }

--- a/stories/select.stories.js
+++ b/stories/select.stories.js
@@ -7,7 +7,7 @@ export default { title: 'Select' };
 export const select = () => (
   <Story>
     <Demo>
-      <div className="Manifold__Select">
+      <div className="Manifold-Select">
         <label for="cheese">Cheese</label>
         <select name="cheese" id="cheese">
           <option>Alpkäse</option>
@@ -39,14 +39,14 @@ export const select = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div class="Manifold__Select">
+        html: `<div class="Manifold-Select">
   <label for="select">Cheese</label>
   <select id="select">…</select>
 </div>`,
         scss: `${comment.block('Select')}
 
-.Manifold__Select {
-  @include mercury.Manifold__Select;
+.Manifold-Select {
+  @include mercury.Select;
 }`,
       }}
     />
@@ -57,7 +57,7 @@ export const selectState = () => (
   <Story>
     <Demo>
       <div>
-        <div className="Manifold__Select">
+        <div className="Manifold-Select">
           <label for="normal-select">Normal</label>
           <select name="normal-select" id="normal-select">
             <option>Alpkäse</option>
@@ -72,7 +72,7 @@ export const selectState = () => (
         </div>
       </div>
       <div>
-        <div className="Manifold__Select">
+        <div className="Manifold-Select">
           <label for="disabled-select">Disabled</label>
           <select disabled name="disabled-select" id="disabled-select">
             <option>Alpkäse</option>
@@ -87,7 +87,7 @@ export const selectState = () => (
         </div>
       </div>
       <div>
-        <div className="Manifold__Select">
+        <div className="Manifold-Select">
           <label for="invalid-select">Invalid</label>
           <select aria-invalid name="invalid-select" id="invalid-select">
             <option>Alpkäse</option>
@@ -138,26 +138,26 @@ export const selectState = () => (
     <Code
       tabs={{
         html: `<!-- normal -->
-<div class="Manifold__Select">
+<div class="Manifold-Select">
   <label for="normal">Normal</label>
   <select name="normal" id="normal">…</select>
 </div>
 
 <!-- disabled -->
-<div class="Manifold__Select">
+<div class="Manifold-Select">
   <label for="disabled">Disabled</label>
   <select disabled name="disabled" id="disabled">…</select>
 </div>
 
 <!-- invalid -->
-<div class="Manifold__Select">
+<div class="Manifold-Select">
   <label for="invalid">Invalid</label>
   <select aria-invalid name="invalid" id="invalid">…</select>
 </div>`,
-        scss: `${comment.block('Input')}
+        scss: `${comment.block('Select')}
 
-.Manifold__Input {
-  @include mercury.Manifold__Input;
+.Manifold-Select {
+  @include mercury.Select;
 }`,
       }}
     />
@@ -167,7 +167,7 @@ export const selectState = () => (
 export const selectInline = () => (
   <Story>
     <Demo>
-      <div className="Manifold__Select Manifold__Select--Inline">
+      <div className="Manifold-Select Manifold-Select--Inline">
         <label for="inline-select">Cheese</label>
         <select name="inline-select" id="inline-select">
           <option>Alpkäse</option>
@@ -193,19 +193,19 @@ export const selectInline = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div class="Manifold__Select Manifold__Select--Inline">
+        html: `<div class="Manifold-Select Manifold-Select--Inline">
   <label for="inline">Inline</label>
   <select aria-invalid name="inline" id="inline">…</select>
 </div>`,
-        scss: `${comment.block('Input')}
+        scss: `${comment.block('Select')}
 
-.Manifold__Input {
-  @include mercury.Manifold__Input;
+.Manifold-Select {
+  @include mercury.Select;
 
   ${comment.modifier}
 
   &--Inline {
-    @include mercury.Manifold__Input--Inline;
+    @include mercury.Select--Inline;
   }
 }`,
       }}

--- a/stories/skeleton.scss
+++ b/stories/skeleton.scss
@@ -5,12 +5,12 @@
 // ----------
 
 .Skeleton {
-  @include mercury.Manifold__Skeleton;
+  @include mercury.Skeleton;
 
   margin: 1rem 0;
 
   &--White {
-    @include mercury.Manifold__Skeleton--White;
+    @include mercury.Skeleton--White;
   }
 
   // ----------

--- a/stories/skeleton.stories.js
+++ b/stories/skeleton.stories.js
@@ -45,23 +45,23 @@ export const skeleton = () => (
     <Code
       tabs={{
         html: `<!-- light background -->
-<p class="Manifold__Skeleton">
+<p class="Manifold-Skeleton">
   💀 This is some text waiting to load
 </p>
 
 <!-- dark background -->
-<p class="Manifold__Skeleton Manifold__Skeleton--White">
+<p class="Manifold-Skeleton Manifold-Skeleton--White">
   💀 This is some text waiting to load
 </p>`,
         scss: `${comment.block('Skeleton Loader')}
 
-.Manifold__Skeleton {
-  @include mercury.Manifold__Skeleton;
+.Manifold-Skeleton {
+  @include mercury.Skeleton;
 
   ${comment.modifier}
 
   &--White {
-    @include mercury.Manifold__Skeleton--White;
+    @include mercury.Skeleton--White;
   }
 }`,
       }}

--- a/stories/storybook/styles.scss
+++ b/stories/storybook/styles.scss
@@ -30,23 +30,23 @@ blockquote {
 }
 
 h1 {
-  @include mercury.Manifold__Typography__HeadingExtraLarge;
+  @include mercury.Typography__HeadingExtraLarge;
 }
 
 h2 {
-  @include mercury.Manifold__Typography__HeadingLarge;
+  @include mercury.Typography__HeadingLarge;
 }
 
 h3 {
-  @include mercury.Manifold__Typography__Heading;
+  @include mercury.Typography__Heading;
 }
 
 h4 {
-  @include mercury.Manifold__Typography__Subheading;
+  @include mercury.Typography__Subheading;
 }
 
 code {
-  @include mercury.Manifold__Typography__MonoBody;
+  @include mercury.Typography__MonoBody;
 
   display: inline-block;
   padding: 0.5em;
@@ -177,7 +177,7 @@ li {
   }
 
   &__Code {
-    @include mercury.Manifold__Typography__MonoBody;
+    @include mercury.Typography__MonoBody;
 
     flex-grow: 1;
     flex-shrink: 0;
@@ -193,7 +193,7 @@ li {
     }
 
     &__Copy {
-      @include mercury.Manifold__Typography__SubheadingSmall;
+      @include mercury.Typography__SubheadingSmall;
 
       position: absolute;
       top: 0.5rem;
@@ -232,7 +232,7 @@ li {
       border-top: 1px solid mercury.$color-grayLight;
 
       &::before {
-        @include mercury.Manifold__Typography__SubheadingSmall;
+        @include mercury.Typography__SubheadingSmall;
 
         position: absolute;
         top: 1rem;

--- a/stories/toast.scss
+++ b/stories/toast.scss
@@ -4,14 +4,14 @@
 // Block
 // ----------
 
-.Manifold__Toast {
-  @include mercury.Manifold__Toast;
+.Manifold-Toast {
+  @include mercury.Toast;
 
   // ----------
   // Modifiers
   // ----------
 
   &--Error {
-    @include mercury.Manifold__Toast--Error;
+    @include mercury.Toast--Error;
   }
 }

--- a/stories/toast.stories.js
+++ b/stories/toast.stories.js
@@ -9,7 +9,7 @@ export default { title };
 export const Toast = () => (
   <Story>
     <Demo>
-      <div role="alert" className="Manifold__Toast">
+      <div role="alert" className="Manifold-Toast">
         <svg aria-label="check" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
           <path
             fill-rule="evenodd"
@@ -39,7 +39,7 @@ export const Toast = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div role="alert" class="Manifold__Toast">
+        html: `<div role="alert" class="Manifold-Toast">
 <svg aria-label="check" role="img" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
     <path
     fill-rule="evenodd"
@@ -51,8 +51,8 @@ export const Toast = () => (
 </div>`,
         scss: `${comment.block(title)}
 
-.Manifold__Banner {
-  @include mercury.Manifold__Banner;
+.Manifold-Toast {
+  @include mercury.Toast;
 }`,
       }}
     />
@@ -62,7 +62,7 @@ export const Toast = () => (
 export const Error = () => (
   <Story>
     <Demo>
-      <div role="alert" className="Manifold__Toast Manifold__Toast--Error">
+      <div role="alert" className="Manifold-Toast Manifold-Toast--Error">
         <svg
           aria-label="wifi-off"
           role="img"
@@ -93,7 +93,7 @@ export const Error = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div role="alert" class="Manifold__Toast Manifold__Toast--Error">
+        html: `<div role="alert" class="Manifold-Toast Manifold-Toast--Error">
         <svg
           aria-label="wifi-off"
           role="img"
@@ -115,16 +115,15 @@ export const Error = () => (
         </p>
       </div>`,
         scss: `${comment.block(title)}
-  
-.Manifold__Banner {
-    @include mercury.Manifold__Banner;
-}
 
-    ${comment.modifier}    
+.Manifold-Toast {
+  @include mercury.Toast;
 
-    .Manifold__Banner--Error {
-        @include mercury.Manifold__Banner--Error;
-    }
+  ${comment.modifier}
+
+  &--Error {
+    @include mercury.Toast--Error;
+  }
 }`,
       }}
     />

--- a/stories/toggle.scss
+++ b/stories/toggle.scss
@@ -1,5 +1,5 @@
 @use "../src/index" as mercury;
 
-.Manifold__Toggle {
-  @include mercury.Manifold__Toggle;
+.Manifold-Toggle {
+  @include mercury.Toggle;
 }

--- a/stories/toggle.stories.js
+++ b/stories/toggle.stories.js
@@ -7,7 +7,7 @@ export default { title: 'Toggle' };
 export const toggle = () => (
   <Story>
     <Demo>
-      <div className="Manifold__Toggle">
+      <div className="Manifold-Toggle">
         <input type="checkbox" name="toggle" id="toggle" value="on" />
         <label for="toggle">Toggle</label>
       </div>
@@ -44,14 +44,14 @@ export const toggle = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div class="Manifold__Toggle">
+        html: `<div class="Manifold-Toggle">
   <input type="checkbox" name="toggle" id="toggle" value="on" />
   <label for="toggle">Toggle</label>
 </div>`,
         scss: `${comment.block('Toggle')}
 
-.Manifold__Toggle {
-  @include mercury.Manifold__Toggle;
+.Manifold-Toggle {
+  @include mercury.Toggle;
 }`,
       }}
     />
@@ -62,13 +62,13 @@ export const toggleState = () => (
   <Story>
     <Demo>
       <div>
-        <div className="Manifold__Toggle">
+        <div className="Manifold-Toggle">
           <input disabled type="checkbox" name="toggle" id="toggle" value="on" />
           <label for="toggle">Disabled Off</label>
         </div>
       </div>
       <div>
-        <div className="Manifold__Toggle">
+        <div className="Manifold-Toggle">
           <input disabled checked type="checkbox" name="toggle" id="toggle" value="on" />
           <label for="toggle">Disabled On</label>
         </div>
@@ -83,14 +83,14 @@ export const toggleState = () => (
     </Description>
     <Code
       tabs={{
-        html: `<div class="Manifold__Toggle">
+        html: `<div class="Manifold-Toggle">
   <input disabled type="checkbox" name="toggle" id="toggle" value="on" />
   <label for="toggle">Toggle</label>
 </div>`,
         scss: `${comment.block('Toggle')}
 
-.Manifold__Toggle {
-  @include mercury.Manifold__Toggle;
+.Manifold-Toggle {
+  @include mercury.Toggle;
 }`,
       }}
     />

--- a/stories/tooltip.scss
+++ b/stories/tooltip.scss
@@ -4,42 +4,42 @@
 // Block
 // ----------
 
-.Manifold__Tooltip__Container {
-  @include mercury.Manifold__Tooltip__Container;
+.Manifold-Tooltip__Container {
+  @include mercury.Tooltip__Container;
 
   &--Down {
-    @include mercury.Manifold__Tooltip__Container--Down;
+    @include mercury.Tooltip__Container--Down;
   }
 
   &--Left {
-    @include mercury.Manifold__Tooltip__Container--Left;
+    @include mercury.Tooltip__Container--Left;
   }
 
   &--Right {
-    @include mercury.Manifold__Tooltip__Container--Right;
+    @include mercury.Tooltip__Container--Right;
   }
 }
 
-.Manifold__Tooltip {
-  @include mercury.Manifold__Tooltip;
+.Manifold-Tooltip {
+  @include mercury.Tooltip;
 
   // ----------
   //  Modifiers
   // ----------
 
   &--Down {
-    @include mercury.Manifold__Tooltip--Down;
+    @include mercury.Tooltip--Down;
   }
 
   &--Left {
-    @include mercury.Manifold__Tooltip--Left;
+    @include mercury.Tooltip--Left;
   }
 
   &--Right {
-    @include mercury.Manifold__Tooltip--Right;
+    @include mercury.Tooltip--Right;
   }
 
   &--Large {
-    @include mercury.Manifold__Tooltip--Large;
+    @include mercury.Tooltip--Large;
   }
 }

--- a/stories/tooltip.stories.js
+++ b/stories/tooltip.stories.js
@@ -3,18 +3,18 @@ import { Story, Demo, Description, Code, comment } from './storybook/blocks';
 import './tooltip.scss';
 
 const title = 'Tooltip';
-const component = 'Manifold__Tooltip';
+const component = 'Manifold-Tooltip';
 
 export default { title, component };
 
 export const defaultTooltip = () => (
   <Story>
     <Demo>
-      <div className="Manifold__Tooltip__Container" aria-describedby="tooltip-1">
-        <button type="button" className="Manifold__Button">
+      <div className="Manifold-Tooltip__Container" aria-describedby="tooltip-1">
+        <button type="button" className="Manifold-Button">
           Hover me
         </button>
-        <div role="tooltip" id="tooltip-1" className="Manifold__Tooltip">
+        <div role="tooltip" id="tooltip-1" className="Manifold-Tooltip">
           Tooltip describing the trigger element.
         </div>
       </div>
@@ -28,26 +28,26 @@ export const defaultTooltip = () => (
       <p>
         Make sure to add the <code>aria-describedby="tooltip-id"</code> attribute to the element
         triggering the tooltip. To use the tooltip without the trigger and position manually, omit
-        the <code>Manifold__Tooltip__Container</code> wrapping element.
+        the <code>Manifold-Tooltip__Container</code> wrapping element.
       </p>
     </Description>
     <Code
       tabs={{
         html: `<!-- ${title} Container -->
-<div class="Manifold__Tooltip__Container" aria-describedby="tooltip-1">
+<div class="Manifold-Tooltip__Container" aria-describedby="tooltip-1">
   <!-- ${title} -->
-  <div role="tooltip" id="tooltip-1" class="Manifold__Tooltip">
+  <div role="tooltip" id="tooltip-1" class="Manifold-Tooltip">
     Tooltip describing the trigger element.
   </div>
 </div>`,
         scss: `${comment.block(title + ' Container')}
 
 .${component}__Container {
-  @include mercury.${component}__Container;
+  @include mercury.${title}__Container;
 }
 
 .${component} {
-  @include mercury.${component};
+  @include mercury.${title};
 }`,
       }}
     />
@@ -58,13 +58,13 @@ export const down = () => (
   <Story>
     <Demo>
       <div
-        className="Manifold__Tooltip__Container Manifold__Tooltip__Container--Down"
+        className="Manifold-Tooltip__Container Manifold-Tooltip__Container--Down"
         aria-describedby="tooltip-1"
       >
-        <button type="button" className="Manifold__Button">
+        <button type="button" className="Manifold-Button">
           Hover me
         </button>
-        <div role="tooltip" id="tooltip-1" className="Manifold__Tooltip Manifold__Tooltip--Down">
+        <div role="tooltip" id="tooltip-1" className="Manifold-Tooltip Manifold-Tooltip--Down">
           Tooltip describing the trigger element.
         </div>
       </div>
@@ -76,29 +76,29 @@ export const down = () => (
     <Code
       tabs={{
         html: `<!-- ${title} Container -->
-<div class="Manifold__Tooltip__Container Manifold__Tooltip__Container--Down" aria-describedby="tooltip-1">
+<div class="Manifold-Tooltip__Container Manifold-Tooltip__Container--Down" aria-describedby="tooltip-1">
   <!-- ${title} -->
-  <div role="tooltip" id="tooltip-1" class="Manifold__Tooltip Manifold__Tooltip--Down">
+  <div role="tooltip" id="tooltip-1" class="Manifold-Tooltip Manifold-Tooltip--Down">
     Tooltip describing the trigger element.
   </div>
 </div>`,
         scss: `${comment.block(title)}
 
 .${component}__Container {
-  @include mercury.${component}__Container;
+  @include mercury.${title}__Container;
 
   &--Down {
-    @include mercury.${component}__Container--Down;
+    @include mercury.${title}__Container--Down;
   }
 }
 
 .${component} {
-  @include mercury.${component};
+  @include mercury.${title};
 
   ${comment.modifier}
 
   &--Down {
-    @include mercury.${component}--Down;
+    @include mercury.${title}--Down;
   }
 }`,
       }}
@@ -110,13 +110,13 @@ export const left = () => (
   <Story>
     <Demo>
       <div
-        className="Manifold__Tooltip__Container Manifold__Tooltip__Container--Left"
+        className="Manifold-Tooltip__Container Manifold-Tooltip__Container--Left"
         aria-describedby="tooltip-1"
       >
-        <button type="button" className="Manifold__Button">
+        <button type="button" className="Manifold-Button">
           Hover me
         </button>
-        <div role="tooltip" id="tooltip-1" className="Manifold__Tooltip Manifold__Tooltip--Left">
+        <div role="tooltip" id="tooltip-1" className="Manifold-Tooltip Manifold-Tooltip--Left">
           Tooltip describing the trigger element.
         </div>
       </div>
@@ -128,29 +128,29 @@ export const left = () => (
     <Code
       tabs={{
         html: `<!-- ${title} Container -->
-<div class="Manifold__Tooltip__Container" aria-describedby="tooltip-1">
+<div class="Manifold-Tooltip__Container" aria-describedby="tooltip-1">
   <!-- ${title} -->
-  <div role="tooltip" id="tooltip-1" class="Manifold__Tooltip Manifold__Tooltip--Left">
+  <div role="tooltip" id="tooltip-1" class="Manifold-Tooltip Manifold-Tooltip--Left">
     Tooltip describing the trigger element.
   </div>
 </div>`,
         scss: `${comment.block(title)}
 
 .${component}__Container {
-  @include mercury.${component}__Container;
+  @include mercury.${title}__Container;
 
   &--Left {
-    @include mercury.${component}__Container--Left;
+    @include mercury.${title}__Container--Left;
   }
 }
 
 .${component} {
-  @include mercury.${component};
+  @include mercury.${title};
 
   ${comment.modifier}
 
   &--Left {
-    @include mercury.${component}--Left;
+    @include mercury.${title}--Left;
   }
 }`,
       }}
@@ -162,13 +162,13 @@ export const right = () => (
   <Story>
     <Demo>
       <div
-        className="Manifold__Tooltip__Container Manifold__Tooltip__Container--Right"
+        className="Manifold-Tooltip__Container Manifold-Tooltip__Container--Right"
         aria-describedby="tooltip-1"
       >
-        <button type="button" className="Manifold__Button">
+        <button type="button" className="Manifold-Button">
           Hover me
         </button>
-        <div role="tooltip" id="tooltip-1" className="Manifold__Tooltip Manifold__Tooltip--Right">
+        <div role="tooltip" id="tooltip-1" className="Manifold-Tooltip Manifold-Tooltip--Right">
           Tooltip describing the trigger element.
         </div>
       </div>
@@ -180,29 +180,29 @@ export const right = () => (
     <Code
       tabs={{
         html: `<!-- ${title} Container -->
-<div class="Manifold__Tooltip__Container" aria-describedby="tooltip-1">
+<div class="Manifold-Tooltip__Container" aria-describedby="tooltip-1">
   <!-- ${title} -->
-  <div role="tooltip" id="tooltip-1" class="Manifold__Tooltip Manifold__Tooltip--Right">
+  <div role="tooltip" id="tooltip-1" class="Manifold-Tooltip Manifold-Tooltip--Right">
     Tooltip describing the trigger element.
   </div>
 </div>`,
         scss: `${comment.block(title)}
 
 .${component}__Container {
-  @include mercury.${component}__Container;
+  @include mercury.${title}__Container;
 
   &--Right {
-    @include mercury.${component}__Container--Right;
+    @include mercury.${title}__Container--Right;
   }
 }
 
 .${component} {
-  @include mercury.${component};
+  @include mercury.${title};
 
   ${comment.modifier}
 
   &--Right {
-    @include mercury.${component}--Right;
+    @include mercury.${title}--Right;
   }
 }`,
       }}
@@ -213,11 +213,11 @@ export const right = () => (
 export const large = () => (
   <Story>
     <Demo>
-      <div class="Manifold__Tooltip__Container" aria-describedby="tooltip-1">
-        <button type="button" className="Manifold__Button">
+      <div class="Manifold-Tooltip__Container" aria-describedby="tooltip-1">
+        <button type="button" className="Manifold-Button">
           Hover me
         </button>
-        <div role="tooltip" id="tooltip-1" class="Manifold__Tooltip Manifold__Tooltip--Large">
+        <div role="tooltip" id="tooltip-1" class="Manifold-Tooltip Manifold-Tooltip--Large">
           Tooltip describing the trigger element that will expand past one line neccessitating a
           line break. Use sparingly! Tooltips should always be brief if possible. They are just
           "tips" after all. 👍
@@ -231,25 +231,25 @@ export const large = () => (
     <Code
       tabs={{
         html: `<!-- ${title} Container -->
-<div class="Manifold__Tooltip__Container" aria-describedby="tooltip-1">
+<div class="Manifold-Tooltip__Container" aria-describedby="tooltip-1">
   <!-- ${title} -->
-  <div role="tooltip" id="tooltip-1" class="Manifold__Tooltip Manifold__Tooltip--Right">
+  <div role="tooltip" id="tooltip-1" class="Manifold-Tooltip Manifold-Tooltip--Right">
     Tooltip describing the trigger element.
   </div>
 </div>`,
         scss: `${comment.block(title)}
 
 .${component}__Container {
-  @include mercury.${component}__Container;
+  @include mercury.${title}__Container;
 }
 
 .${component} {
-  @include mercury.${component};
+  @include mercury.${title};
 
   ${comment.modifier}
 
   &--Large {
-    @include mercury.${component}--Large;
+    @include mercury.${title}--Large;
   }
 }`,
       }}

--- a/stories/typography.scss
+++ b/stories/typography.scss
@@ -4,86 +4,86 @@
 //  Typography
 // -----------
 
-.Manifold__Typography {
+.Manifold-Typography {
   // ----------
   //  Elements
   // ----------
 
   &__Body {
-    @include mercury.Manifold__Typography__Body;
+    @include mercury.Typography__Body;
   }
 
   &__Caption {
-    @include mercury.Manifold__Typography__Caption;
+    @include mercury.Typography__Caption;
   }
 
   &__Heading {
-    @include mercury.Manifold__Typography__Heading;
+    @include mercury.Typography__Heading;
   }
 
   &__HeadingLarge {
-    @include mercury.Manifold__Typography__HeadingLarge;
+    @include mercury.Typography__HeadingLarge;
   }
 
   &__HeadingExtraLarge {
-    @include mercury.Manifold__Typography__HeadingExtraLarge;
+    @include mercury.Typography__HeadingExtraLarge;
   }
 
   &__MonoBody {
-    @include mercury.Manifold__Typography__MonoBody;
+    @include mercury.Typography__MonoBody;
   }
 
   &__MonoCaption {
-    @include mercury.Manifold__Typography__MonoCaption;
+    @include mercury.Typography__MonoCaption;
   }
 
   &__MonoLabel {
-    @include mercury.Manifold__Typography__MonoLabel;
+    @include mercury.Typography__MonoLabel;
   }
 
   &__Label {
-    @include mercury.Manifold__Typography__Label;
+    @include mercury.Typography__Label;
   }
 
   &__Subheading {
-    @include mercury.Manifold__Typography__Subheading;
+    @include mercury.Typography__Subheading;
   }
 
   &__SubheadingSmall {
-    @include mercury.Manifold__Typography__SubheadingSmall;
+    @include mercury.Typography__SubheadingSmall;
   }
 
   &__SidebarBigTitle {
-    @include mercury.Manifold__Typography__SidebarBigTitle;
+    @include mercury.Typography__SidebarBigTitle;
   }
 
   &__SidebarSmallTitle {
-    @include mercury.Manifold__Typography__SidebarSmallTitle;
+    @include mercury.Typography__SidebarSmallTitle;
   }
 
   // Small Screens
 
   &__SmallScreenBody {
-    @include mercury.Manifold__Typography__SmallScreenBody;
+    @include mercury.Typography__SmallScreenBody;
   }
 
   &__SmallScreenCaption {
-    @include mercury.Manifold__Typography__SmallScreenCaption;
+    @include mercury.Typography__SmallScreenCaption;
   }
 
   &__SmallScreenHeading {
-    @include mercury.Manifold__Typography__SmallScreenHeading;
+    @include mercury.Typography__SmallScreenHeading;
   }
 
   &__SmallScreenHeadingLarge {
-    @include mercury.Manifold__Typography__SmallScreenHeadingLarge;
+    @include mercury.Typography__SmallScreenHeadingLarge;
   }
 
   &__SmallScreenHeadingExtraLarge {
-    @include mercury.Manifold__Typography__SmallScreenHeadingExtraLarge;
+    @include mercury.Typography__SmallScreenHeadingExtraLarge;
   }
 
   &__SmallScreenLabel {
-    @include mercury.Manifold__Typography__SmallScreenLabel;
+    @include mercury.Typography__SmallScreenLabel;
   }
 }

--- a/stories/typography.stories.js
+++ b/stories/typography.stories.js
@@ -11,7 +11,7 @@ const LOREM_IPSUM = 'Everything you need to build an add-ons marketplace';
 const TypographyDisplay = ({ component, name, element, children, smallScreen = false }) => (
   <Story>
     <Demo>
-      <div className={`Manifold__${title}__${component}`}>{LOREM_IPSUM}</div>
+      <div className={`Manifold-${title}__${component}`}>{LOREM_IPSUM}</div>
     </Demo>
     <Description>
       <h1>{name}</h1>
@@ -19,21 +19,21 @@ const TypographyDisplay = ({ component, name, element, children, smallScreen = f
     </Description>
     <Code
       tabs={{
-        html: `<${element} class="Manifold__${title}__${component}">
+        html: `<${element} class="Manifold-${title}__${component}">
   ${LOREM_IPSUM}
 </${element}>`,
         scss: `${comment.block(title)}
 
-.Manifold__${title} {
+.Manifold-${title} {
   ${comment.element}
 
   &__${component} {
-    @include mercury.Manifold__${title}__${smallScreen ? 'SmallScreen' : ''}${component};${
+    @include mercury.${title}__${smallScreen ? 'SmallScreen' : ''}${component};${
           smallScreen
             ? `
 
     @media (min-width: 600px) {
-      @include mercury.Manifold__${title}__${component};
+      @include mercury.${title}__${component};
     }`
             : ''
         }


### PR DESCRIPTION
This changes the following things:

**Remove `Manifold__` prefix from all mixins**

```diff
-@include mercury.Manifold__Typography__Body;
+@include mercury.Typography__Body;
```

**Hyphen for namespace, not double underscore**

```diff
-.Manifold__Button {
+.Manifold-Button {
```

The fact that the preview link works should tell you it’s renamed correctly—if any `@include`s were misnamed it would fail to build.