### PR TITLE
Make Typography modifiers

### DIFF
--- a/figma/targets/sass.ts
+++ b/figma/targets/sass.ts
@@ -56,7 +56,7 @@ function buildTypography(typography: DesignTokens['typography']): string {
     .map(
       ([key, styles]) =>
         `
-@mixin Typography__${capitalize(key)} {${cssifyObject(styles)}}`
+@mixin Typography--${capitalize(key)} {${cssifyObject(styles)}}`
     )
     .join('\n\n');
 

--- a/src/design-tokens/_typography.scss
+++ b/src/design-tokens/_typography.scss
@@ -152,7 +152,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
   'Segoe UI', Helvetica, Arial, sans-serif, 'Apple Color Emoji',
   'Segoe UI Emoji';
 
-@mixin Typography__Body {
+@mixin Typography--Body {
   font-size: 16px;
   font-weight: 400;
   letter-spacing: normal;
@@ -162,7 +162,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__Caption {
+@mixin Typography--Caption {
   font-size: 12px;
   font-weight: 400;
   letter-spacing: normal;
@@ -172,7 +172,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__Heading {
+@mixin Typography--Heading {
   font-size: 20px;
   font-weight: 400;
   letter-spacing: normal;
@@ -182,7 +182,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__HeadingExtraLarge {
+@mixin Typography--HeadingExtraLarge {
   font-size: 32px;
   font-weight: 500;
   letter-spacing: normal;
@@ -192,7 +192,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__HeadingLarge {
+@mixin Typography--HeadingLarge {
   font-size: 25px;
   font-weight: 400;
   letter-spacing: normal;
@@ -202,7 +202,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__Label {
+@mixin Typography--Label {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: normal;
@@ -212,7 +212,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__MonoBody {
+@mixin Typography--MonoBody {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: normal;
@@ -222,7 +222,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     Menlo, monospace;
 }
 
-@mixin Typography__MonoCaption {
+@mixin Typography--MonoCaption {
   font-size: 10px;
   font-weight: 400;
   letter-spacing: normal;
@@ -232,7 +232,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     Menlo, monospace;
 }
 
-@mixin Typography__MonoLabel {
+@mixin Typography--MonoLabel {
   font-size: 12px;
   font-weight: 400;
   letter-spacing: normal;
@@ -242,7 +242,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     Menlo, monospace;
 }
 
-@mixin Typography__SidebarBigTitle {
+@mixin Typography--SidebarBigTitle {
   font-size: 16px;
   font-weight: 600;
   letter-spacing: normal;
@@ -252,7 +252,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SidebarSmallTitle {
+@mixin Typography--SidebarSmallTitle {
   font-size: 14px;
   font-weight: 700;
   letter-spacing: normal;
@@ -262,7 +262,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenBody {
+@mixin Typography--SmallScreenBody {
   font-size: 16px;
   font-weight: 400;
   letter-spacing: normal;
@@ -272,7 +272,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenCaption {
+@mixin Typography--SmallScreenCaption {
   font-size: 13px;
   font-weight: 400;
   letter-spacing: normal;
@@ -282,7 +282,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenHeading {
+@mixin Typography--SmallScreenHeading {
   font-size: 18px;
   font-weight: 400;
   letter-spacing: normal;
@@ -292,7 +292,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenHeadingExtraLarge {
+@mixin Typography--SmallScreenHeadingExtraLarge {
   font-size: 26px;
   font-weight: 500;
   letter-spacing: normal;
@@ -302,7 +302,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenHeadingLarge {
+@mixin Typography--SmallScreenHeadingLarge {
   font-size: 22px;
   font-weight: 400;
   letter-spacing: normal;
@@ -312,7 +312,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenLabel {
+@mixin Typography--SmallScreenLabel {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: normal;
@@ -322,7 +322,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SmallScreenSubheading {
+@mixin Typography--SmallScreenSubheading {
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -332,7 +332,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__Subheading {
+@mixin Typography--Subheading {
   font-size: 13px;
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -342,7 +342,7 @@ $typography-subheadingSmall-fontFamily: -apple-system, BlinkMacSystemFont,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji';
 }
 
-@mixin Typography__SubheadingSmall {
+@mixin Typography--SubheadingSmall {
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.04em;

--- a/stories/typography.scss
+++ b/stories/typography.scss
@@ -9,81 +9,81 @@
   //  Elements
   // ----------
 
-  &__Body {
-    @include mercury.Typography__Body;
+  &--Body {
+    @include mercury.Typography--Body;
   }
 
-  &__Caption {
-    @include mercury.Typography__Caption;
+  &--Caption {
+    @include mercury.Typography--Caption;
   }
 
-  &__Heading {
-    @include mercury.Typography__Heading;
+  &--Heading {
+    @include mercury.Typography--Heading;
   }
 
-  &__HeadingLarge {
-    @include mercury.Typography__HeadingLarge;
+  &--HeadingLarge {
+    @include mercury.Typography--HeadingLarge;
   }
 
-  &__HeadingExtraLarge {
-    @include mercury.Typography__HeadingExtraLarge;
+  &--HeadingExtraLarge {
+    @include mercury.Typography--HeadingExtraLarge;
   }
 
-  &__MonoBody {
-    @include mercury.Typography__MonoBody;
+  &--MonoBody {
+    @include mercury.Typography--MonoBody;
   }
 
-  &__MonoCaption {
-    @include mercury.Typography__MonoCaption;
+  &--MonoCaption {
+    @include mercury.Typography--MonoCaption;
   }
 
-  &__MonoLabel {
-    @include mercury.Typography__MonoLabel;
+  &--MonoLabel {
+    @include mercury.Typography--MonoLabel;
   }
 
-  &__Label {
-    @include mercury.Typography__Label;
+  &--Label {
+    @include mercury.Typography--Label;
   }
 
-  &__Subheading {
-    @include mercury.Typography__Subheading;
+  &--Subheading {
+    @include mercury.Typography--Subheading;
   }
 
-  &__SubheadingSmall {
-    @include mercury.Typography__SubheadingSmall;
+  &--SubheadingSmall {
+    @include mercury.Typography--SubheadingSmall;
   }
 
-  &__SidebarBigTitle {
-    @include mercury.Typography__SidebarBigTitle;
+  &--SidebarBigTitle {
+    @include mercury.Typography--SidebarBigTitle;
   }
 
-  &__SidebarSmallTitle {
-    @include mercury.Typography__SidebarSmallTitle;
+  &--SidebarSmallTitle {
+    @include mercury.Typography--SidebarSmallTitle;
   }
 
   // Small Screens
 
-  &__SmallScreenBody {
-    @include mercury.Typography__SmallScreenBody;
+  &--SmallScreenBody {
+    @include mercury.Typography--SmallScreenBody;
   }
 
-  &__SmallScreenCaption {
-    @include mercury.Typography__SmallScreenCaption;
+  &--SmallScreenCaption {
+    @include mercury.Typography--SmallScreenCaption;
   }
 
-  &__SmallScreenHeading {
-    @include mercury.Typography__SmallScreenHeading;
+  &--SmallScreenHeading {
+    @include mercury.Typography--SmallScreenHeading;
   }
 
-  &__SmallScreenHeadingLarge {
-    @include mercury.Typography__SmallScreenHeadingLarge;
+  &--SmallScreenHeadingLarge {
+    @include mercury.Typography--SmallScreenHeadingLarge;
   }
 
-  &__SmallScreenHeadingExtraLarge {
-    @include mercury.Typography__SmallScreenHeadingExtraLarge;
+  &--SmallScreenHeadingExtraLarge {
+    @include mercury.Typography--SmallScreenHeadingExtraLarge;
   }
 
-  &__SmallScreenLabel {
-    @include mercury.Typography__SmallScreenLabel;
+  &--SmallScreenLabel {
+    @include mercury.Typography--SmallScreenLabel;
   }
 }

--- a/stories/typography.stories.js
+++ b/stories/typography.stories.js
@@ -11,7 +11,7 @@ const LOREM_IPSUM = 'Everything you need to build an add-ons marketplace';
 const TypographyDisplay = ({ component, name, element, children, smallScreen = false }) => (
   <Story>
     <Demo>
-      <div className={`Manifold-${title}__${component}`}>{LOREM_IPSUM}</div>
+      <div className={`Manifold-${title}--${component}`}>{LOREM_IPSUM}</div>
     </Demo>
     <Description>
       <h1>{name}</h1>
@@ -19,7 +19,7 @@ const TypographyDisplay = ({ component, name, element, children, smallScreen = f
     </Description>
     <Code
       tabs={{
-        html: `<${element} class="Manifold-${title}__${component}">
+        html: `<${element} class="Manifold-${title}--${component}">
   ${LOREM_IPSUM}
 </${element}>`,
         scss: `${comment.block(title)}
@@ -27,13 +27,13 @@ const TypographyDisplay = ({ component, name, element, children, smallScreen = f
 .Manifold-${title} {
   ${comment.element}
 
-  &__${component} {
-    @include mercury.${title}__${smallScreen ? 'SmallScreen' : ''}${component};${
+  &--${component} {
+    @include mercury.${title}--${smallScreen ? 'SmallScreen' : ''}${component};${
           smallScreen
             ? `
 
     @media (min-width: 600px) {
-      @include mercury.${title}__${component};
+      @include mercury.${title}--${component};
     }`
             : ''
         }


### PR DESCRIPTION
`Typography--Body` makes more sense than `Typography__Body`, don’t you think?

Since we renamed everything™ recently this seems like a good chance to change it.

(also, if you disagree, please say so! I want to have common-sense naming)