### PR TITLE
Hide spinners for type="number"

### DIFF
--- a/src/components/_input.scss
+++ b/src/components/_input.scss
@@ -42,6 +42,7 @@
     transition-duration: 150ms;
     transition-property: border-color;
     appearance: none;
+    -moz-appearance: textfield; // stylelint-disable-line
 
     @media (min-width: 600px) {
       @include typography.Typography__Body;
@@ -59,6 +60,11 @@
       @include typography.Typography__MonoBody;
 
       text-align: right;
+    }
+
+    &::-webkit-inner-spin-button,
+    &::-webkit-outer-spin-button {
+      display: none;
     }
   }
 


### PR DESCRIPTION
Hides these little goobers:

![Screen Shot 2020-04-24 at 13 58 35](https://user-images.githubusercontent.com/1369770/80252001-c54f8b00-8633-11ea-9fd2-d3b3ab724016.png)
